### PR TITLE
Контроллер для событий

### DIFF
--- a/ItHappend.RestAPI/Controllers/EventController.cs
+++ b/ItHappend.RestAPI/Controllers/EventController.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Security.Claims;
+using AutoMapper;
+using ItHappend.RestAPI.Authentication;
+using ItHappend.RestAPI.Filters;
+using ItHappend.RestAPI.Models;
+using ItHappened.Application;
+using ItHappened.Domain;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ItHappend.RestAPI.Controllers
+{
+    [Authorize]
+    [GlobalException]
+    [Route("tracks/{trackId}/events")]
+    public class EventController : ControllerBase
+    {
+        private readonly IEventService _eventService;
+        private readonly IMapper _mapper;
+
+        public EventController(IEventService eventService, IMapper mapper)
+        {
+            _eventService = eventService;
+            _mapper = mapper;
+        }
+        
+        [HttpGet]
+        public IActionResult GetEvents([FromRoute]Guid trackId)
+        {
+            var userId = GetUserId();
+            var events = _eventService.GetEvents(userId, trackId);
+            
+            var result = new GetEventsResponse()
+            {
+                Events = _mapper.Map<IEnumerable<EventDto>, GetEventsResponseItem[]>(events),
+            };
+            return Ok(result);
+        }
+        
+        [HttpPost]
+        public IActionResult CreateEvent([FromRoute]Guid trackId, [FromBody]CreateEventRequest request)
+        {
+            var userId = GetUserId();
+            var customizations = _mapper.Map<CustomizationsDto>(request.Customizations);
+            
+            var @event = _eventService.CreateEvent(userId, trackId, request.CreatedAt, customizations);
+
+            var result = _mapper.Map<CreateEventResponse>(@event);
+            return Ok(result);
+        }
+        
+        [HttpDelete]
+        [Route("{eventId}")]
+        public IActionResult DeleteEvent([FromRoute]Guid eventId)
+        {
+            var userId = GetUserId();
+            
+            var @event = _eventService.DeleteEvent(userId, eventId);
+
+            var result = new DeleteEventResponse { Id = @event};
+            return Ok(result);
+        }
+        
+        [HttpPut]
+        [Route("{eventId}")]
+        public IActionResult EditEvent([FromRoute]Guid trackId, [FromRoute]Guid eventId, [FromBody] EditEventRequest request)
+        {
+            var userId = GetUserId();
+            var customizations = _mapper.Map<CustomizationsDto>(request.Customizations);
+            var eventDto = new EventDto(eventId, request.CreatedAt, trackId, customizations);
+            var @event = _eventService.EditEvent(userId, eventDto);
+
+            var result = _mapper.Map<EditEventResponse>(@event);
+            return Ok(result);
+        }
+
+        private Guid GetUserId()
+        {
+            return Guid.Parse(User.FindFirstValue(JwtClaimTypes.Id));
+        }
+    }
+}

--- a/ItHappend.RestAPI/Controllers/EventController.cs
+++ b/ItHappend.RestAPI/Controllers/EventController.cs
@@ -70,7 +70,7 @@ namespace ItHappend.RestAPI.Controllers
         {
             var userId = GetUserId();
             var customizations = _mapper.Map<CustomizationsDto>(request.Customizations);
-            var eventDto = new EventDto(eventId, request.CreatedAt, trackId, customizations);
+            var eventDto = new EventToEditDto(eventId, customizations);
             var @event = _eventService.EditEvent(userId, eventDto);
 
             var result = _mapper.Map<EditEventResponse>(@event);

--- a/ItHappend.RestAPI/EventMapperProfile.cs
+++ b/ItHappend.RestAPI/EventMapperProfile.cs
@@ -1,0 +1,32 @@
+using System;
+using AutoMapper;
+using ItHappend.RestAPI.Models;
+using ItHappened.Domain;
+
+namespace ItHappend.RestAPI
+{
+    public class EventMapperProfile : Profile
+    {
+        public EventMapperProfile()
+        {
+            CreateMap<CustomizationsDto, CustomizationsModel>();
+            CreateMap<CustomizationsModel, CustomizationsDto>();
+            CreateMap<EventDto, GetEventsResponseItem>()
+                .ForMember(
+                    _ => _.Customizations,
+                    opt =>
+                        opt.MapFrom(s => s.CustomizationDto));
+
+            CreateMap<EventDto, CreateEventResponse>()
+                .ForMember(
+                    _ => _.Customizations,
+                    opt =>
+                        opt.MapFrom(s => s.CustomizationDto));
+            CreateMap<EventDto, EditEventResponse>()
+                .ForMember(
+                    _ => _.Customizations,
+                    opt =>
+                        opt.MapFrom(s => s.CustomizationDto));
+        }
+    }
+}

--- a/ItHappend.RestAPI/ItHappend.RestAPI.csproj
+++ b/ItHappend.RestAPI/ItHappend.RestAPI.csproj
@@ -9,6 +9,8 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="AutoMapper" Version="10.1.1" />
+      <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     </ItemGroup>
 

--- a/ItHappend.RestAPI/Models/CreateEventRequest.cs
+++ b/ItHappend.RestAPI/Models/CreateEventRequest.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace ItHappend.RestAPI.Models
+{
+    public class CreateEventRequest
+    {
+        public DateTime CreatedAt { get; set; }
+        public CustomizationsModel Customizations { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Models/CreateEventResponse.cs
+++ b/ItHappend.RestAPI/Models/CreateEventResponse.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ItHappend.RestAPI.Models
+{
+    public class CreateEventResponse
+    {
+        public Guid Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public CustomizationsModel Customizations { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Models/CustomizationsModel.cs
+++ b/ItHappend.RestAPI/Models/CustomizationsModel.cs
@@ -1,0 +1,12 @@
+namespace ItHappend.RestAPI.Models
+{
+    public class CustomizationsModel
+    {
+        public string Comment { get; set; }
+        public double? GeotagLatitude { get; set; }
+        public double? GeotagLongitude { get; set; }
+        public string PhotoUrl { get; set; }
+        public int? Rating { get; set; }
+        public double? Scale { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Models/DeleteEventResponse.cs
+++ b/ItHappend.RestAPI/Models/DeleteEventResponse.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace ItHappend.RestAPI.Models
+{
+    public class DeleteEventResponse
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Models/EditEventRequest.cs
+++ b/ItHappend.RestAPI/Models/EditEventRequest.cs
@@ -4,7 +4,6 @@ namespace ItHappend.RestAPI.Models
 {
     public class EditEventRequest
     {
-        public DateTime CreatedAt { get; set; }
         public CustomizationsModel Customizations { get; set; }
     }
 }

--- a/ItHappend.RestAPI/Models/EditEventRequest.cs
+++ b/ItHappend.RestAPI/Models/EditEventRequest.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace ItHappend.RestAPI.Models
+{
+    public class EditEventRequest
+    {
+        public DateTime CreatedAt { get; set; }
+        public CustomizationsModel Customizations { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Models/EditEventResponse.cs
+++ b/ItHappend.RestAPI/Models/EditEventResponse.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ItHappend.RestAPI.Models
+{
+    public class EditEventResponse
+    {
+        public Guid Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public CustomizationsModel Customizations { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Models/GetEventsResponse.cs
+++ b/ItHappend.RestAPI/Models/GetEventsResponse.cs
@@ -1,0 +1,7 @@
+namespace ItHappend.RestAPI.Models
+{
+    public class GetEventsResponse
+    {
+        public GetEventsResponseItem[] Events { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Models/GetEventsResponseItem.cs
+++ b/ItHappend.RestAPI/Models/GetEventsResponseItem.cs
@@ -1,0 +1,12 @@
+using System;
+using ItHappened.Domain;
+
+namespace ItHappend.RestAPI.Models
+{
+    public class GetEventsResponseItem
+    {
+        public Guid Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public CustomizationsModel Customizations { get; set; }
+    }
+}

--- a/ItHappend.RestAPI/Startup.cs
+++ b/ItHappend.RestAPI/Startup.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using AutoMapper;
 using ItHappend.RestAPI.Authentication;
 using ItHappened.Application;
 using ItHappened.Domain.Repositories;
@@ -22,6 +23,17 @@ namespace ItHappend.RestAPI
 
         public IConfiguration Configuration { get; }
 
+        private void ConfigureMapper(IServiceCollection services)
+        {
+            var mappingConfig = new MapperConfiguration(mc =>
+            {
+                mc.AddProfile(new EventMapperProfile());
+            });
+
+            IMapper mapper = mappingConfig.CreateMapper();
+            services.AddSingleton(mapper);
+        }
+
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
@@ -42,8 +54,14 @@ namespace ItHappend.RestAPI
                     };
                 });
 
+            ConfigureMapper(services);
+            
             services.AddSingleton<IUserRepository, UserRepositoryInMemory>();
+            services.AddSingleton<IEventRepository, EventRepositoryInMemory>();
+            services.AddSingleton<ITrackRepository, TrackRepositoryInMemory>();
             services.AddSingleton<IUserService, UserService>();
+            services.AddSingleton<ITracksService, TracksService>();
+            services.AddSingleton<IEventService, EventService>();
             services.AddSingleton<IJwtIssuer, JwtIssuer>();
             services.AddControllers();
         }

--- a/ItHappend.Tests/ServiceTests/EventServiceTest.cs
+++ b/ItHappend.Tests/ServiceTests/EventServiceTest.cs
@@ -207,7 +207,7 @@ namespace ItHappend.Tests.ServiceTests
             // act
             var customizations = new Customizations();
 
-            var result = eventService.EditEvent(_testUserId, new EventDto(_testEventToUpdate));
+            var result = eventService.EditEvent(_testUserId, new EventToEditDto(_testEventToUpdate));
 
             // assert
             Assert.AreEqual(_testEventId, result.Id);
@@ -249,7 +249,7 @@ namespace ItHappend.Tests.ServiceTests
             var eventService = new EventService(eventRepository, _trackRepository);
 
             // act
-            var result = eventService.EditEvent(_testUserId, new EventDto(@event));
+            var result = eventService.EditEvent(_testUserId, new EventToEditDto(@event));
 
             // assert
             Assert.AreEqual(_testEventId, result.Id);
@@ -275,7 +275,7 @@ namespace ItHappend.Tests.ServiceTests
             // act
             try
             {
-                var result = eventService.EditEvent(_testUserId, new EventDto(@event));
+                var result = eventService.EditEvent(_testUserId, new EventToEditDto(@event));
             }
             catch (DomainException e)
             {

--- a/ItHappened/Application/EventService.cs
+++ b/ItHappened/Application/EventService.cs
@@ -38,17 +38,17 @@ namespace ItHappened.Application
             return new EventDto(createdEvent);
         }
 
-        public EventDto EditEvent(Guid userId, EventDto eventDto)
+        public EventDto EditEvent(Guid userId, EventToEditDto eventDto)
         {
-            var track = TryGetAccessToTrack(userId, eventDto.TrackId);
             var oldEvent = _eventRepository.TryGetById(eventDto.Id);
+            var track = TryGetAccessToTrack(userId, oldEvent.TrackId);
 
             var oldCustomizations = Customizations.GetCustomizationTypes(oldEvent.Customization.GetDto());
             var allowedCustomizations = track.AllowedCustomizations.Concat(oldCustomizations);
-            CheckNotAllowedCustomizationsInDto(eventDto.CustomizationDto, allowedCustomizations, eventDto.TrackId);
+            CheckNotAllowedCustomizationsInDto(eventDto.CustomizationDto, allowedCustomizations, track.Id);
             
             var customizations = new Customizations(eventDto.CustomizationDto, allowedCustomizations);
-            var editedEvent = new Event(eventDto.Id, oldEvent.CreatedAt, eventDto.TrackId, customizations);
+            var editedEvent = new Event(eventDto.Id, oldEvent.CreatedAt, track.Id, customizations);
             var editResult = _eventRepository.TryUpdate(editedEvent);
             return new EventDto(editResult);
         }

--- a/ItHappened/Application/IEventService.cs
+++ b/ItHappened/Application/IEventService.cs
@@ -9,7 +9,7 @@ namespace ItHappened.Application
     {
         IEnumerable<EventDto> GetEvents(Guid userId, Guid trackId);
         EventDto CreateEvent(Guid userId, Guid trackId, DateTime createdAt, CustomizationsDto customizationsDto);
-        EventDto EditEvent(Guid userId, EventDto eventDto);
+        EventDto EditEvent(Guid userId, EventToEditDto eventDto);
         Guid DeleteEvent(Guid userId, Guid eventId);
     }
 }

--- a/ItHappened/Domain/EventToEditDto.cs
+++ b/ItHappened/Domain/EventToEditDto.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ItHappened.Domain
+{
+    public class EventToEditDto
+    {
+        public EventToEditDto(Event @event)
+        {
+            Id = @event.Id;
+            CustomizationDto = @event.Customization.GetDto();
+        }
+
+        public EventToEditDto(Guid id, CustomizationsDto customizationDto)
+        {
+            Id = id;
+            CustomizationDto = customizationDto;
+        }
+
+        public readonly Guid Id;
+        public readonly CustomizationsDto CustomizationDto;
+    }
+}


### PR DESCRIPTION
closes #57 

Не переписывала метод редактирования событий сервиса.
В качестве маппера использовала [automapper](http://automapper.org/)

Получается очень много повторяющихся классов, особенно для Response. Возможно, стоит использовать один класс, например EventView, который возвращается из PUT и POST запроса, а также для GET. И те данные, которые мы выделяем пользователю как "видимые" - одинаковы для этих запросов, а значит, при изменении полей нужно будет исправить только один класс. Собственно, я так и сделала для кастомизаций - сделала CustomiztionsModel.