### PR TITLE
Пример валидации данных пользователя!!!

### DIFF
--- a/ItHappend.RestAPI/Filters/ValidationFilter.cs
+++ b/ItHappend.RestAPI/Filters/ValidationFilter.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace ItHappend.RestAPI.Filters
+{
+    public class ValidationFilter : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!context.ModelState.IsValid)
+            {
+                context.Result = new BadRequestObjectResult(
+                    context.ModelState.SelectMany(x => x.Value.Errors)
+                    .Select(x => x.ErrorMessage).ToArray());
+            }
+
+            base.OnActionExecuting(context);
+        }
+    }
+}

--- a/ItHappend.RestAPI/Models/CreateEventRequest.cs
+++ b/ItHappend.RestAPI/Models/CreateEventRequest.cs
@@ -1,10 +1,21 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace ItHappend.RestAPI.Models
 {
-    public class CreateEventRequest
+    public class CreateEventRequest : IValidatableObject
     {
+        [Required]
         public DateTime CreatedAt { get; set; }
+        [Required]
         public CustomizationsModel Customizations { get; set; }
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (CreatedAt == new DateTime())
+            {
+                yield return new ValidationResult("CreatedAt is invalid or not not found in request body", new[] { "CreatedAt" });
+            }
+        }
     }
 }

--- a/ItHappend.RestAPI/Startup.cs
+++ b/ItHappend.RestAPI/Startup.cs
@@ -64,6 +64,10 @@ namespace ItHappend.RestAPI
             {
                 options.Filters.Add(typeof(GlobalExceptionAttribute));
             });
+            services.AddControllers(options =>
+            {
+                options.Filters.Add(typeof(ValidationFilter));
+            });
             
             ConfigureMapper(services);
             


### PR DESCRIPTION
Посмотрите, пожалуйста, норм ли такой вариант. [источник](https://www.devtrends.co.uk/blog/handling-errors-in-asp.net-core-web-api)

Атрибут [Required] позволяет получить текст с сообщением о том, что поле обязательно.
Также, в IValidatableObject можно прописать кастомную валидацию, например, что правильно указаны строки с названиями кастомизаций. Можно добавлять несколько ошибок - тогда пользователь получит все ошибки связанные с его запросом.

 ValidationFilter при этом отлавливает все ошибки связанные с ошибкой конвертации тела запроса в модели. Если, например в строке даты указать символы, то ошибка будет такая. Это, конечно, не очень пока "для пользователя". но 400-й статус код + есть указания поля.
`[
    "The JSON value could not be converted to System.DateTime. Path: $.CreatedAt | LineNumber: 2 | BytePositionInLine: 23."
]`

Проблема - в валидации появляется (частично) логика. Сюда напрашивается валидация значений, например - не пустой логин. Эта проверка должна быть и в домене. Намного удобнее в функции валидации поля проверять, например, что рейтинг от 0 до 10 и писать соответствующее сообщение. Тогда каждый объект отвечает за свою валидацию.
Тогда в домене я бы обошлась OutOfRangeException и другими базовыми исключениями, которые бы не обрабатывала а всю валидацию с нормальными сообщениями делала в АПИ. 

Это реквест не на merge в мастер, а просто экспериментальная ветка
