### PR TITLE
time bug

### DIFF
--- a/it_happend.frontend/package-lock.json
+++ b/it_happend.frontend/package-lock.json
@@ -10372,6 +10372,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
+    "moment-timezone": {
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/it_happend.frontend/package.json
+++ b/it_happend.frontend/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.0",
     "moment": "^2.29.1",
+    "moment-timezone": "^0.5.31",
     "multiselect-react-dropdown": "^1.6.1",
     "react": "^17.0.1",
     "react-confirm-alert": "^2.6.2",

--- a/it_happend.frontend/src/Components/Events/EventBox.js
+++ b/it_happend.frontend/src/Components/Events/EventBox.js
@@ -107,7 +107,7 @@ export default function EventBox(props) {
     }
     event.preventDefault()
   }
-console.log(props.createdAt)
+
   return (
     <div>
       {!isDeleted

--- a/it_happend.frontend/src/Components/Events/EventBox.js
+++ b/it_happend.frontend/src/Components/Events/EventBox.js
@@ -4,9 +4,11 @@ import { Card, CardActions, CardContent, Typography, Button } from "@material-ui
 import Rating from '@material-ui/lab/Rating';
 import { Link } from "react-router-dom"
 import { deleteEvent } from './../../api';
-import moment from 'moment'
+import moment from 'moment-timezone' 
 import 'moment/locale/ru'
 moment.locale('ru')
+
+const timezoneOffset = (new Date()).getTimezoneOffset();
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -107,7 +109,7 @@ export default function EventBox(props) {
     }
     event.preventDefault()
   }
-
+console.log(props.createdAt)
   return (
     <div>
       {!isDeleted
@@ -119,7 +121,7 @@ export default function EventBox(props) {
               color="textSecondary"
               gutterBottom
             >
-              {moment(props.createdAt).format('LL h:mm a')}
+              {moment(props.createdAt).tz(moment.tz.guess()).format('LL h:mm a')}
             </Typography>
             {props.comment != null
               ?

--- a/it_happend.frontend/src/Components/Events/EventBox.js
+++ b/it_happend.frontend/src/Components/Events/EventBox.js
@@ -8,8 +8,6 @@ import moment from 'moment-timezone'
 import 'moment/locale/ru'
 moment.locale('ru')
 
-const timezoneOffset = (new Date()).getTimezoneOffset();
-
 const useStyles = makeStyles((theme) => ({
   root: {
     minWidth: 275,

--- a/it_happend.frontend/src/Components/Events/EventForm.js
+++ b/it_happend.frontend/src/Components/Events/EventForm.js
@@ -269,8 +269,10 @@ export default function EventForm({ allowedCustomizations, event, onSave, isEdit
             listOfCustoms["GeotagLatitude"] = parseFloat(geotag.value.latitude);
             listOfCustoms["GeotagLongitude"] = parseFloat(geotag.value.longitude);
         }
+        var date = new Date()
+        date.setMinutes(date.getMinutes() - (new Date()).getTimezoneOffset());
         const eventContent = {
-            "CreatedAt": isEdit ? event.CreatedAt : new Date(),
+            "CreatedAt": isEdit ? event.CreatedAt : date,
             "customizations": listOfCustoms
         }
         if (!errors) {

--- a/it_happend.frontend/src/TrackBox.js
+++ b/it_happend.frontend/src/TrackBox.js
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { deleteTrack } from './api';
 import { Edit, Delete, ExpandMore, ExpandLess } from '@material-ui/icons';
 import { Link } from "react-router-dom"
-import moment from 'moment'
+import moment from 'moment-timezone'
 import 'moment/locale/ru'
 moment.locale('ru')
 
@@ -90,7 +90,7 @@ export default function TrackBox(props) {
                                 <Typography
 
                                     variant="subtitle1" className={classes.flex1}>{name} </Typography>
-                                <Typography variant="subtitle2" className={classes.flex1}>{moment(createdAt).format('LL')}</Typography>
+                                <Typography variant="subtitle2" className={classes.flex1}>{moment(createdAt).tz(moment.tz.guess()).format('LL')}</Typography>
                                 <Link to={`/editTrack`} onClick={onRouteToEvents}>
                                     <IconButton
                                         aria-label="edit"

--- a/it_happend.frontend/src/TrackCreation.js
+++ b/it_happend.frontend/src/TrackCreation.js
@@ -70,10 +70,11 @@ export default function TrackCreation({isEdit = false}) {
     var listOfCustoms = Object.keys(customs)
       .filter(function (k) { return customs[k] })
       .map(String)
-
+    var date = new Date()
+    date.setMinutes(date.getMinutes() - (new Date()).getTimezoneOffset());
     const trackInfo = {
       "name": text,
-      "CreatedAt": new Date(),
+      "CreatedAt": date,
       "allowedCustomizations": listOfCustoms
     }
     setButtonDisabled(true);


### PR DESCRIPTION
изменил отображение времени с moment на moment-timezone, сам определяет и учитывает текущую зону при добавлении, но баг крылся не в этом ,а в том как жс через жопу работает со временем.
При добавлении мы использовали new Date() -он дает текущую дату с часовым поясом, но если мы используем его для апи,то пояс обрезается,а во время вносятся изменения. То есть 3 00 по москве в апи идут как 0 00 по гринвичу. Когда же мы получаем дату из апи, жс добавляет пояс обратно, наш пояс , а поправку не вносит,в итоге получаем 0 00 по Москве(отсюда потерянные три часа),moment-timezone это не фиксит,ведь пояс наш указан.
Чтобы решить проблему приходится самому изменять дату перед передачей апи с  учетом текущего пояса.
